### PR TITLE
Fix shebang of unluac script

### DIFF
--- a/unluac.sh
+++ b/unluac.sh
@@ -1,7 +1,7 @@
-#!/bin/sh
+#!/bin/bash
 
 # unluac.sh
-# A shell script to make unluac.jar easier to use. (Still requires the JRE, though)
+# A bash script to make unluac.jar easier to use. (Still requires the JRE, though)
 
 if [ $# -eq 0 ]; then
 	echo "Use this shell script to bulk-decompile Playdate Lua bytecode with unluac."


### PR DESCRIPTION
This script relies on bash features, so the shebang must specify bash as interpreter, not regular /bin/sh.